### PR TITLE
Potential fix for code scanning alert no. 10: Log Injection

### DIFF
--- a/src/utils/email.py
+++ b/src/utils/email.py
@@ -41,7 +41,9 @@ def send_spoofed_email(to_email, from_name, from_email, subject, html_content):
             server.login(SMTP_CONFIG['username'], SMTP_CONFIG['password'])
             server.send_message(msg)
             
-        logger.info(f"Email sent successfully to {to_email} from {from_name} <{sender_email}>")
+        sanitized_to_email = to_email.replace('\r\n', '').replace('\n', '')
+        sanitized_from_name = from_name.replace('\r\n', '').replace('\n', '')
+        logger.info(f"Email sent successfully to {sanitized_to_email} from {sanitized_from_name} <{sender_email}>")
         return True
         
     except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/xtial/GhostX/security/code-scanning/10](https://github.com/xtial/GhostX/security/code-scanning/10)

To fix the log injection issue, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from the `to_email` and `from_name` parameters to prevent log injection. This can be done using the `replace` method to replace `\r\n` and `\n` with empty strings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
